### PR TITLE
fix: update Twitter URL and correct typos in documentation

### DIFF
--- a/docs/Learn/Bitlayer PoS/AboutFinality.md
+++ b/docs/Learn/Bitlayer PoS/AboutFinality.md
@@ -8,9 +8,9 @@ sidebar_position: 90
 
 In this initial phase, Bitlayer adopts the best security model: PoS + Multisig, working with multiple MPC custody platforms, ultilizing 100% EVM-Compatible environment to onboard users and developers.
 
-At this stage, there're up to 21 canonical validators are reponsible for proposing blocks and maintaining the blockchain, the consensus is like `clique` in go-ethereum, but with **System contracts** to deal with staking and validator managements. 
+At this stage, there're up to 21 canonical validators are responsible for proposing blocks and maintaining the blockchain, the consensus is like `clique` in go-ethereum, but with **System contracts** to deal with staking and validator managements. 
 
-At this stage, Bitlayer adopts the longest chain strategy (AKA the largest total difficulty strategy) to select the cononical chain if there are multi-branch at a height. **So, the latest few blocks may be reorg**.
+At this stage, Bitlayer adopts the longest chain strategy (AKA the largest total difficulty strategy) to select the canonical chain if there are multi-branch at a height. **So, the latest few blocks may be reorg**.
 
 For finality at Bitlayer PoS stage:
 

--- a/docs/Learn/FAQs/Contact-Details.md
+++ b/docs/Learn/FAQs/Contact-Details.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 Website：https://www.bitlayer.org/
 
-Twitter: https://twitter.com/BitLayerLabs
+Twitter: https://x.com/BitLayerLabs
 
 Discord: https://discord.com/invite/GGSjNyD8nj
 

--- a/docs/Learn/Introduction/Introduction.md
+++ b/docs/Learn/Introduction/Introduction.md
@@ -61,4 +61,4 @@ Bitlayer is rapidly evolving, with significant milestones already achieved and e
 
 By combining Bitcoin's security with cutting-edge scalability and programmability, Bitlayer is poised to redefine the possibilities of Bitcoin Layer 2. Dive into our documentation to explore the technical details and start building on Bitlayer today!
 
-Stay updated on our progress by following our [Twitter](https://twitter.com/BitLayerLabs) or joining our active [Discord](https://discord.com/invite/GGSjNyD8nj) / [Telegram](https://t.me/bitlayerofficial) community. You can also read our [Blog](https://blog.bitlayer.org/) to stay abreast of the latest Bitlayer developments.
+Stay updated on our progress by following our [Twitter](https://x.com/BitLayerLabs) or joining our active [Discord](https://discord.com/invite/GGSjNyD8nj) / [Telegram](https://t.me/bitlayerofficial) community. You can also read our [Blog](https://blog.bitlayer.org/) to stay abreast of the latest Bitlayer developments.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -141,7 +141,7 @@ const config = {
               },
               {
                 label: 'Twitter',
-                href: 'https://twitter.com/BitLayerLabs',
+                href: 'https://x.com/BitLayerLabs',
               },
             ],
           },


### PR DESCRIPTION

- Replaced outdated Twitter URL (https://twitter.com/) with the updated x.com format (https://x.com/) to align with the platform's rebranding.
- Fixed typos:
  - "reponsible" → "responsible"
  - "cononical" → "canonical"

Continuing to refine and improve the documentation!
