### PR TITLE
docs: add OpenChainBench live RPC latency benchmark link

### DIFF
--- a/docs/Learn/Bitlayer PoS/Networks.md
+++ b/docs/Learn/Bitlayer PoS/Networks.md
@@ -19,6 +19,8 @@ This reference guide provides a listing of the different Bitlayer networks and p
 | Contract Addresses          | Refer to the [Contract Addresses page](/docs/Build/DeveloperResources/Contracts.md)                         |
 | Connect Wallet              | [Click here to connect your wallet to Bitlayer Mainnet](https://chainlist.org/?search=bitlayer) |
 
+> Live latency benchmarks for these endpoints (p50/p90/p99, 3 regions, updated every 60 s): [OpenChainBench Bitlayer RPC](https://openchainbench.com/benchmarks/bitlayer-rpc)
+
 [Introducing Bitlayer Mainnet-V1: Unlocking the Potential of Bitcoin](https://medium.com/@Bitlayer/introducing-bitlayer-mainnet-v1-unlocking-the-potential-of-bitcoin-56c5fa2159fd) 
 
 Click the above link to know more about our Mainnet-V1.
@@ -45,4 +47,3 @@ The "currency symbol" is required by some wallets like MetaMask.
 | Provider Name               | Provider URL| 
 | --------------------------- | ------------------ | 
 | Ankr                        | https://bitlayer-rpc.com/              |Mainnet|
-


### PR DESCRIPTION
Adds a reference to [OpenChainBench](https://openchainbench.com/benchmarks/bitlayer-rpc), which independently monitors Bitlayer RPC endpoint latency (p50/p90/p99, `eth_getBlockByNumber`, 3 probe regions, updated every 60 seconds).